### PR TITLE
Typos found by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ This program was written by Will Clarke, University of Oxford. Contributions to 
 
 Particular thanks go to Tomáš Pšorn for contributing the Bruker interface, and to Jack Miller for the Varian interface.
 
-Some GE test data comes from the [BIG GABA](https://www.nitrc.org/projects/biggaba/) dataset whichw as funded by NIH grant R01 EB016089. Please see Mikkelsen M et al. Big GABA: Edited MR spectroscopy at 24 research sites. NeuroImage 2017;159:32–45. doi: 10.1016/j.neuroimage.2017.07.021 for more information.
+Some GE test data comes from the [BIG GABA](https://www.nitrc.org/projects/biggaba/) dataset which was funded by NIH grant R01 EB016089. Please see Mikkelsen M et al. Big GABA: Edited MR spectroscopy at 24 research sites. NeuroImage 2017;159:32–45. doi: 10.1016/j.neuroimage.2017.07.021 for more information.

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,7 @@ exclude =
     # Exclude Definitions file so that things can be on one line.
     spec2nii/nifti_mrs/definitions.py
 max-line-length=120
+
+[codespell]
+skip =versioneer.py,_version.py,ge_hdr_fields.py,ge_pfile.py,ge_read_pfile.py,fileiobase.py,varian.py
+ignore-words-list = te,varian

--- a/spec2nii/GSL/gslfunctions.py
+++ b/spec2nii/GSL/gslfunctions.py
@@ -119,7 +119,7 @@ def calc_prs(gs, phi, debug):
         print(f'GR = {gr[0]:10.7f} {gr[1]:10.7f} {gr[2]:10.7f}')
         print(f'GS = {gs[0]:10.7f} {gs[1]:10.7f} {gs[2]:10.7f}')
 
-    # otation
+    # rotation
     if phi != 0.0:
         # Rotate by phi around the S axis
         if debug:

--- a/spec2nii/anonymise.py
+++ b/spec2nii/anonymise.py
@@ -31,7 +31,7 @@ def anon_nifti_mrs(args):
     hdr_ext = json.loads(nifti_mrs_img.header.extensions[hdr_ext_codes.index(44)].get_content())
 
     # Loop through fields. Remove those which are marked for anonymisation
-    # Either those fileds which are standard-defined and are marked for anonymisation,
+    # Either those fields which are standard-defined and are marked for anonymisation,
     # or user-defined which are marked 'private'.
     pvt_re = re.compile(r'private_')
 

--- a/spec2nii/dcm2niiOrientation/orientationFuncs.py
+++ b/spec2nii/dcm2niiOrientation/orientationFuncs.py
@@ -85,7 +85,7 @@ def nifti_dicom2mat(orient, patientPosition, xyzMM, verbose=False):
         Q[:, 2] = Q[:, 2] * -1
 
     # next scale matrix
-    # I think dcm2niix reversees the pixel spacing
+    # I think dcm2niix reverses the pixel spacing
     # https://github.com/rordenlab/dcm2niix/blob/485c387c93bbca3b29b93403dfde211c4bc39af6/console/nii_dicom.cpp#L5403
     xyzMM[1], xyzMM[0] = xyzMM[0], xyzMM[1]
     diagVox = np.diag(xyzMM)

--- a/spec2nii/dicomfunctions.py
+++ b/spec2nii/dicomfunctions.py
@@ -219,7 +219,7 @@ def process_siemens_csi(img, verbose):
                       img.csa_header['tags']['PixelSpacing']['items'][1],
                       img.csa_header['tags']['SliceThickness']['items'][0]])
 
-    # Note that half_shift = True. For an explination see spec2nii/notes/seimens.md
+    # Note that half_shift = True. For an explination see spec2nii/notes/siemens.md
     currNiftiOrientation = dcm_to_nifti_orientation(imageOrientationPatient,
                                                     imagePositionPatient,
                                                     xyzMM,

--- a/spec2nii/jmrui.py
+++ b/spec2nii/jmrui.py
@@ -107,7 +107,7 @@ def read_mrui(file_path):
 
     :return: Data in numpy format (npoints x nframes)
     :return: header dict
-    :return: Additional information sotred as strings in file
+    :return: Additional information sorted as strings in file
     '''
     with open(file_path, 'br') as fp:
         # Header and data is stored as big endian double

--- a/spec2nii/nifti_mrs/definitions.py
+++ b/spec2nii/nifti_mrs/definitions.py
@@ -158,7 +158,7 @@ standard_defined = {
     'RxCoil':
         (str,
          None,
-         "Name or description of recieve RF coil.",
+         "Name or description of receive RF coil.",
          False),
     # 5.3 Sequence information
     'SequenceName':

--- a/spec2nii/nifti_mrs/hdr_ext.py
+++ b/spec2nii/nifti_mrs/hdr_ext.py
@@ -4,13 +4,13 @@ import json
 
 class hdr_ext:
     """Class to hold meta data stored in a NIfTI MRS header extension.
-    Required fields must be passed to initilise,
-    Default dimension information atomatically gnerated, but may be modifed by set_dim_info method.
-    Standard defined meta-data and user-defined data can be added uisng set_standard_def and
+    Required fields must be passed to initialise,
+    Default dimension information automatically gnerated, but may be modified by set_dim_info method.
+    Standard defined meta-data and user-defined data can be added using set_standard_def and
     set_user_def respectively.
     """
     def __init__(self, spec_frequency, resonant_nucleus):
-        """Initilise class object with the two required bits of meta-data
+        """Initialise class object with the two required bits of meta-data
         Set default dimension information.
         Inputs:
             spec_frequency: Spectrometer frequency in MHz,
@@ -45,7 +45,7 @@ class hdr_ext:
             dim: May be (0,1,2) or ("5th","6th","7th")
             tag: Must be one of the defined dimension tag strings.
             info: Optional, free-form use string.
-            hdr: Dict containing relavent header value names and values.
+            hdr: Dict containing relevant header value names and values.
         """
         if tag not in dimension_tags.keys():
             raise ValueError("tag must be one of the defined dimension tag.")

--- a/spec2nii/nifti_mrs/nifti_mrs.py
+++ b/spec2nii/nifti_mrs/nifti_mrs.py
@@ -14,10 +14,10 @@ def get_mrs_class(nifti=2):
         """Class to contain a NIfTI MRS dataset. Derived from nibabel's Nifti2Image."""
 
         def __init__(self, dataobj, affine, dwelltime, header_ext, header=None, extra=None, file_map=None):
-            """Initilise a NIfTI MRS object which can be saved to disk.
+            """Initialise a NIfTI MRS object which can be saved to disk.
             :param dataobj: Four to seven dimensional complex numpy array.
             :param affine: None or (4,4) array-like
-                            homogenous affine giving relationship between voxel coordinates and
+                            homogeneous affine giving relationship between voxel coordinates and
                             world coordinates.  Affine can also be None.  In this case,
                             ``obj.affine`` also returns None, and the affine as written to disk
                             will depend on the file format.

--- a/spec2nii/philips.py
+++ b/spec2nii/philips.py
@@ -95,7 +95,7 @@ def read_sdat(filename, samples, rows):
 
 
 def _philips_orientation(params):
-    '''Calculate the orientation affine from the spar parmaeters.'''
+    '''Calculate the orientation affine from the spar parameters.'''
 
     angle_lr = params['lr_angulation']
     angle_ap = params['ap_angulation']

--- a/spec2nii/philips_data_list.py
+++ b/spec2nii/philips_data_list.py
@@ -17,7 +17,7 @@ index_headers = ['typ', 'mix', 'dyn', 'card', 'echo', 'loca',
                  'chan', 'extr1', 'extr2', 'kx', 'ky', 'kz',
                  'aver', 'sign', 'rf', 'grad', 'enc', 'rtop',
                  'rr', 'size', 'offset']
-indicies = ['chan', 'aver', 'dyn', 'card', 'echo', 'loca', 'extr1', 'extr2']
+indices = ['chan', 'aver', 'dyn', 'card', 'echo', 'loca', 'extr1', 'extr2']
 
 defaults = {'chan': 'DIM_COIL',
             'aver': 'DIM_DYN',
@@ -57,7 +57,7 @@ def read_data_list_pair(data_file, list_file, spar_file):
                                spar_file.name])
 
         kept_ind = []
-        for ii, sha in zip(indicies, data.shape[1:]):
+        for ii, sha in zip(indices, data.shape[1:]):
             if sha > 1:
                 kept_ind.append(ii)
 
@@ -113,7 +113,7 @@ def _read_data(data_file, df):
                 curr_mix_df = curr_df.loc[curr_df.mix == mix, :]
                 shape = []
                 shape.append(int(curr_mix_df['size'].max() / 8))
-                for ind in indicies:
+                for ind in indices:
                     shape.append(curr_mix_df[ind].max() + 1)
                 output_dict[f'{tt}_{mix}'] = np.zeros(shape, dtype=np.complex)
 
@@ -127,7 +127,7 @@ def _read_data(data_file, df):
             output_dict[tt][:, cdf.chan, cdf.loca] = raw[offset:(offset + dsize)]
         else:
             mix = cdf.mix
-            ind = [cdf[ii] for ii in indicies]
+            ind = [cdf[ii] for ii in indices]
             ind = tuple([slice(None), ] + ind)
             output_dict[f'{tt}_{mix}'][ind] = raw[offset:(offset + dsize)]
         offset += dsize

--- a/spec2nii/spec2nii.py
+++ b/spec2nii/spec2nii.py
@@ -136,7 +136,7 @@ class spec2nii:
         parser_txt.add_argument("-i", "--imagingfreq", type=float,
                                 help="Imaging (central) frequency in MHz", required=True)
         parser_txt.add_argument("-b", "--bandwidth", type=float,
-                                help="Reciever bandwidth (sweepwidth) in Hz.", required=True)
+                                help="Receiver bandwidth (sweepwidth) in Hz.", required=True)
         parser_txt.add_argument("-n", "--nucleus", type=str,
                                 help="Nucleus string. e.g. 1H or 31P.", required=True)
         parser_txt.add_argument("-a", "--affine", type=str, help="NIfTI affine file", required=False, metavar='<file>')
@@ -215,7 +215,7 @@ class spec2nii:
         parser_extract.set_defaults(func=self.extract,
                                     nifti1=False)
 
-        parser_insert = subparsers.add_parser('insert', help='Insert json fomated file into existing NIfTI-MRS file.')
+        parser_insert = subparsers.add_parser('insert', help='Insert json formatted file into existing NIfTI-MRS file.')
         parser_insert.add_argument('file', help='NIFTI-MRS file', type=Path)
         parser_insert.add_argument('json_file', help='JSON file to insert', type=Path)
         parser_insert.add_argument("-f", "--fileout", type=str,
@@ -258,7 +258,7 @@ class spec2nii:
             print('No files to write.')
 
     def implement_overrides(self, args):
-        """Implement any command line overides for essential parameters."""
+        """Implement any command line overrides for essential parameters."""
         for nifti_mrs_img in self.imageOut:
             if args.override_dwelltime:
                 nifti_mrs_img.set_dwell_time(args.override_dwelltime)

--- a/spec2nii/twixfunctions.py
+++ b/spec2nii/twixfunctions.py
@@ -34,7 +34,7 @@ defaults = {'vb': {'Col': 'time',
 
 
 def process_twix(twixObj, base_name_out, name_in, dataKey, dim_overides, quiet=False, verbose=False, remove_os=False):
-    """Process a twix file. Identify type of MRS and then pass to the relavent function."""
+    """Process a twix file. Identify type of MRS and then pass to the relevant function."""
 
     if twixObj.hdr.Meas.lFinalMatrixSizePhase \
             and twixObj.hdr.Meas.lFinalMatrixSizeRead:
@@ -122,7 +122,7 @@ def process_svs(twixObj, base_name_out, name_in, dataKey, dim_overides, remove_o
     # Extract metadata
     meta_obj = extractTwixMetadata(twixObj['hdr'], basename(twixObj[dataKey].filename))
 
-    # Identify what those indicies are
+    # Identify what those indices are
     # If cha is one: loop over 3rd and higher dims and make 2D images
     # If cha isn't present one: loop over 2nd and higher dims and make 1D images
     # Don't write here, just fill up class property lists for later writing
@@ -169,9 +169,9 @@ def process_svs(twixObj, base_name_out, name_in, dataKey, dim_overides, remove_o
             dim_tags[idx] = tag
 
     # Permute the order of dimension in the data
-    orignal = list(range(1, squeezedData.ndim))
+    original = list(range(1, squeezedData.ndim))
     new = [twixObj[dataKey].sqzDims.index(dd) for dd in dim_order]
-    reord_data = np.moveaxis(squeezedData, orignal, new)
+    reord_data = np.moveaxis(squeezedData, original, new)
 
     # Now assemble data
     nifit_mrs_out = []
@@ -306,7 +306,7 @@ def twix2DCMOrientation(mapVBVDHdr, verbose=False):
 
 
 def examineTwix(twixObj, fileName, mraid):
-    """ Print formated twix contents"""
+    """ Print formatted twix contents"""
 
     print(f'Contents of file: {fileName}')
 


### PR DESCRIPTION
Add a codespell section in `setup.cfg` in the process.

Vendored files should probably be fixed upstream, although I wasn't able to identify upstream for all projects:
* `versioneer`   https://github.com/python-versioneer/python-versioneer
* `VESPA`
* `nmrglue`      https://github.com/jjhelmus/nmrglue