### PR TITLE
Redundant comparison

### DIFF
--- a/spec2nii/dicomfunctions.py
+++ b/spec2nii/dicomfunctions.py
@@ -578,8 +578,7 @@ def identify_integrated_references(img, inst_num):
         if inst_num <= num_ref:
             # First ecc calibration references
             return 1, '_ecc'
-        elif inst_num > num_ref\
-                and inst_num <= (num_ref * 2):
+        elif inst_num <= (num_ref * 2):
             # First quantitation calibration references
             return 2, '_quant'
         elif inst_num <= (total_dyn - num_ref)\


### PR DESCRIPTION
Because of:
```python
        if inst_num <= num_ref
```
this test is always True:
```python
        elif inst_num > num_ref
```

Fixes this LGTM.com alert:
https://lgtm.com/projects/g/wtclarke/spec2nii/snapshot/b63b22985eda580eb21552378eae05a28247ad8c/files/spec2nii/dicomfunctions.py?sort=name&dir=ASC&mode=heatmap#xd2b9c850d6540567:1