### PR TITLE
Add missing meta output to GE oslaser pathway.

### DIFF
--- a/spec2nii/GE/ge_pfile.py
+++ b/spec2nii/GE/ge_pfile.py
@@ -162,7 +162,7 @@ def _process_oslaser(pfile):
 
     dwelltime = 1 / pfile.hdr.rhr_spectral_width
 
-    return data, dwelltime, fname_suffix
+    return data, meta, dwelltime, fname_suffix
 
 
 def _process_gaba(pfile):


### PR DESCRIPTION
Closes #31 