### PR TITLE
Apply relevant refurb suggestions

### DIFF
--- a/spec2nii/GE/ge_hdr_fields.py
+++ b/spec2nii/GE/ge_hdr_fields.py
@@ -82,7 +82,7 @@ def get_pfile_hdr_fields(version):
     version_major = int(np.trunc(version))
 
     # ARC 20220209 : consistent with previous _version_major mapping
-    if version_major in [7, 8]:
+    if version_major in (7, 8):
         plist.append(('rhr_rh_rdbm_rev',          ct.c_float))
         plist.append(('pad_xx',                   ct.c_char * 12))
         plist.append(('rhr_rh_scan_date',         ct.c_char * 10))
@@ -517,7 +517,7 @@ def get_pfile_hdr_fields(version):
         plist.append(('rhi_user47',               ct.c_float))
         plist.append(('rhi_user48',               ct.c_float))
 
-    elif version_major in [11, 12]:
+    elif version_major in (11, 12):
         plist.append(('rhr_rh_rdbm_rev',          ct.c_float))
         plist.append(('pad_xx',                   ct.c_char * 12))
         plist.append(('rhr_rh_scan_date',         ct.c_char * 10))
@@ -2076,7 +2076,7 @@ def get_pfile_hdr_fields(version):
         plist.append(('pad_xx',                   ct.c_char * 51))
         plist.append(('rhi_image_uid',            ct.c_char * 32))
 
-    elif version_major in [24, 25]:
+    elif version_major in (24, 25):
         plist.append(('rhr_rh_rdbm_rev',          ct.c_float))
         plist.append(('pad_xx',                   ct.c_char * 12))
         plist.append(('rhr_rh_scan_date',         ct.c_char * 10))
@@ -2303,7 +2303,7 @@ def get_pfile_hdr_fields(version):
         plist.append(('pad_xx',                   ct.c_char * 51))
         plist.append(('rhi_image_uid',            ct.c_char * 32))
 
-    elif version_major in [26, 27, 28]:
+    elif version_major in (26, 27, 28):
         plist.append(('rhr_rh_rdbm_rev',           ct.c_float))
         plist.append(('rhr_rdb_hdr_off_data',      ct.c_int))
         plist.append(('pad_xx',                    ct.c_char * 84))

--- a/spec2nii/GE/ge_pfile.py
+++ b/spec2nii/GE/ge_pfile.py
@@ -91,7 +91,7 @@ def _process_svs_pfile(pfile):
 
     if psd == 'probe-p':
         data, meta, dwelltime, fname_suffix = _process_probe_p(pfile)
-    elif psd in ['oslaser', 'slaser_cni']:
+    elif psd in ('oslaser', 'slaser_cni'):
         data, meta, dwelltime, fname_suffix = _process_oslaser(pfile)
     elif psd == 'gaba':
         data, meta, dwelltime, fname_suffix = _process_gaba(pfile)

--- a/spec2nii/GE/ge_read_pfile.py
+++ b/spec2nii/GE/ge_read_pfile.py
@@ -147,7 +147,7 @@ class Pfile:
             # may well be redundant anyway, since revision number has
             # previously been validated in _version
             if offset in \
-                    [
+                    (
                         61464,   # bjs from Matlab script for ver = 9
                         66072,
                         145908,
@@ -157,7 +157,7 @@ class Pfile:
                         213684,  # 26.002
                         219828,  # 27.000
                         228020   # 28.003
-                    ]:
+                    ):
                 return True
             else:
                 return False
@@ -180,7 +180,7 @@ class Pfile:
         
         if psd == 'probe-p':
             mapper = PfileMapper
-        elif psd in ['oslaser', 'slaser_cni']:
+        elif psd in ('oslaser', 'slaser_cni'):
             mapper = PfileMapperSlaser
         elif psd == 'presscsi':
             mapper = PfileMapper

--- a/spec2nii/fileiobase.py
+++ b/spec2nii/fileiobase.py
@@ -421,7 +421,7 @@ def uc_from_freqscale(scale, obs, unit='ppm'):
     scale = np.array(scale)
     size = len(scale)
 
-    if unit in ['ppm', 'hz', 'khz']:
+    if unit in ('ppm', 'hz', 'khz'):
         complex = False
 
         min = scale.min()

--- a/spec2nii/nifti_mrs/hdr_ext.py
+++ b/spec2nii/nifti_mrs/hdr_ext.py
@@ -54,7 +54,7 @@ class hdr_ext:
                     "info": info,
                     "hdr": hdr}
 
-        if dim in [0, 1, 2]:
+        if dim in (0, 1, 2):
             self.dim_info[dim] = new_info
         elif dim in ("5th", "6th", "7th"):
             if dim == "5th":

--- a/spec2nii/philips.py
+++ b/spec2nii/philips.py
@@ -259,7 +259,7 @@ def _vax_to_ieee_single_float(data):
             # note 16777216.0 == 2^24
             val = sign_mult * (0.5 + (fract / 16777216.0)) * pow(2.0, expon - 128.0)
             f.append(val)
-        elif expon == 0 and sign == 0:
+        elif expon == sign == 0:
             f.append(0)
         else:
             f.append(0)

--- a/spec2nii/varian.py
+++ b/spec2nii/varian.py
@@ -1876,7 +1876,7 @@ def uninterleave_data(data):
     # determind the output dtype
     rdt = data.dtype.name
 
-    if rdt == 'int16' or rdt == "float32":
+    if rdt in ("int16", "float32"):
         cdt = "complex64"
     elif rdt == 'int32':
         cdt = "complex128"


### PR DESCRIPTION
* [FURB108]: Use `x in (y, z)` instead of `x == y or x == z`
* [FURB109]: Replace `in [x, y, z]` with `in (x, y, z)`
* [FURB124]: Use `x == y == z` instead of `x == y and x == z`