### PR TITLE
Philips .data/.list conversion

### DIFF
--- a/spec2nii/Philips/philips.py
+++ b/spec2nii/Philips/philips.py
@@ -205,7 +205,10 @@ def spar_to_nmrs_hdrext(spar_dict):
     # # 5.3 Sequence information
     # 'SequenceName'
     # 'ProtocolName'
-    set_standard_def('ProtocolName', spar_dict, 'scan_id')
+    try:
+        obj.set_standard_def('ProtocolName', spar_dict['scan_id'])
+    except AttributeError:
+        pass
     # # 5.4 Sequence information
     # 'PatientPosition'
     try:


### PR DESCRIPTION
Small modification which was causing an issue converting in Philips data/list format from our 7 T system.

Error
```
  File "/philips_data_list.py", line 97, in read_data_list_pair
    and (special_case == 'hyper' or 'hyper' in meta['ProtocolName'].lower()):
  File "/miniconda3/envs/fslmrs/lib/python3.7/site-packages/nifti_mrs/hdr_ext.py", line 222, in __getitem__
    return self.to_dict()[key]
KeyError: 'ProtocolName'
```

Caused by ProtocolName not being populated in 'meta'