### PR TITLE
Do not install tests in site-packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='spec2nii',
       url='https://github.com/wtclarke/spec2nii',
       long_description=long_description,
       long_description_content_type="text/markdown",
-      packages=find_packages(),
+      packages=find_packages(exclude=["tests*"]),
       install_requires=install_requires,
       classifiers=[
           "Programming Language :: Python :: 3",


### PR DESCRIPTION
Fixes:

```
python3.11 -m venv _e
. _e/bin/activate
pip install spec2nii
ls -l _e/lib/python3.11/site-packages/tests/
```

```
total 160
-rw-r--r--. 1 ben ben    0 Jul  8 18:39 __init__.py
-rw-r--r--. 1 ben ben  153 Jul  8 18:39 io_for_tests.py
drwxr-xr-x. 1 ben ben 1866 Jul  8 18:39 __pycache__
-rw-r--r--. 1 ben ben 2031 Jul  8 18:39 test_anon.py
-rw-r--r--. 1 ben ben 3089 Jul  8 18:39 test_auto.py
[...]
-rw-r--r--. 1 ben ben 1371 Jul  8 18:39 test_varian.py
```

That is, `spec2nii` is incorrectly installing its `tests/` as a top-level `tests` package since https://github.com/wtclarke/spec2nii/commit/232189c4ce02b2f184bd2fdf4353582754763af6 switched to `setuptools.find_packages()`.