### PR TITLE
BF: Insert extract dump on non compliant files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This document contains the Spec2nii release history in reverse chronological ord
 - Fixed a bug in Philips spar/sdat orientations - this will affect voxels with rotations in more than one axes.
 - Fixed a bug in Philips DICOM orientations - this will affect voxels with rotations in more than one axes.
 - Python 3.7 now in [end of life](https://devguide.python.org/versions/) status and is no longer supported.
+- `spec2nii dump/extract/insert` can now be used to inspect and fix non-compliant NIfTI-MRS files.
 
 0.6.10 (Monday 10th July 2023)
 ------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 This document contains the Spec2nii release history in reverse chronological order.
 
-0.6.11 (WIP)
+0.6.11 (Friday 28th July 2023)
 ------------------------------
 - Fixed a bug in Philips spar/sdat orientations - this will affect voxels with rotations in more than one axes.
 - Fixed a bug in Philips DICOM orientations - this will affect voxels with rotations in more than one axes.

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,4 +6,4 @@ dependencies:
  - scipy
  - brukerapi>=0.1.8
  - pandas
- - nifti-mrs>=1.0.0
+ - nifti-mrs>=1.0.2

--- a/spec2nii/other.py
+++ b/spec2nii/other.py
@@ -15,7 +15,7 @@ def dump_headers(args):
     :param args: Command line arguments
     """
     # Load file
-    nifti_mrs_img = NIFTI_MRS(args.file)
+    nifti_mrs_img = NIFTI_MRS(args.file, validate_on_creation=False)
 
     # Print NIfTI header
     print('NIfTI header: ')
@@ -31,7 +31,7 @@ def extract_hdr_ext(args):
 
     :param args: Command line arguments
     """
-    nifti_mrs_img = NIFTI_MRS(args.file)
+    nifti_mrs_img = NIFTI_MRS(args.file, validate_on_creation=False)
 
     if args.outdir:
         args.outdir.mkdir(exist_ok=True, parents=True)
@@ -58,7 +58,7 @@ def insert_hdr_ext(args):
 
     # Load data
     try:
-        nifti_mrs_img = NIFTI_MRS(args.file)
+        nifti_mrs_img = NIFTI_MRS(args.file, validate_on_creation=False)
         nifti_mrs_img.hdr_ext = new_hdr
 
     except NotNIFTI_MRS:


### PR DESCRIPTION
`spec2nii dump/extract/insert` can now be used to inspect and fix non-compliant NIfTI-MRS files.
