### PR TITLE
Avoid redefining Python builtins

### DIFF
--- a/spec2nii/fileiobase.py
+++ b/spec2nii/fileiobase.py
@@ -421,7 +421,7 @@ def uc_from_freqscale(scale, obs, unit='ppm'):
     size = len(scale)
 
     if unit in ('ppm', 'hz', 'khz'):
-        complex = False
+        cplex = False
 
         min = scale.min()
         max = scale.max()
@@ -445,7 +445,7 @@ def uc_from_freqscale(scale, obs, unit='ppm'):
         mesg = f'{unit} is not a supported unit.'
         raise ValueError(mesg)
 
-    return unit_conversion(size, complex, sw, obs, car)
+    return unit_conversion(size, cplex, sw, obs, car)
 
 
 def open_towrite(filename, overwrite=False, mode='wb'):

--- a/tests/test_philips_orientation_dcm_spar_new.py
+++ b/tests/test_philips_orientation_dcm_spar_new.py
@@ -163,12 +163,12 @@ def run_case(case, working_dir):
 @pytest.mark.orientation
 def test_dcm_spar_orientations(tmp_path):
     def dcm_call(x, name):
-        input = base_dir / x
+        dcm = base_dir / x
         run(
             ['spec2nii', 'philips_dcm',
              '-o', tmp_path,
              '-f', name,
-             input]
+             dcm]
         )
 
     def ss_call(x, name):


### PR DESCRIPTION
Both [`complex`](https://docs.python.org/3/library/functions.html#complex) and [`input`](https://docs.python.org/3/library/functions.html#input) are Python builtin functions.

Note that `complex` → `cplex` is consistent with this class definition:
https://github.com/wtclarke/spec2nii/blob/fee31415e84bc8dc306f2115dffafddcee03c32c/spec2nii/fileiobase.py#L97-L106