### PR TITLE
`in [x, y, z]` → `in (x, y, z)`

### DIFF
--- a/spec2nii/GE/ge_pfile.py
+++ b/spec2nii/GE/ge_pfile.py
@@ -95,9 +95,9 @@ def _process_svs_pfile(pfile):
         data, meta, dwelltime, fname_suffix = _process_probe_p(pfile)
     elif psd in ('oslaser', 'slaser_cni'):
         data, meta, dwelltime, fname_suffix = _process_oslaser(pfile)
-    elif psd in ('slaser'):
+    elif psd == 'slaser':
         data, meta, dwelltime, fname_suffix = _process_slaser(pfile)
-    elif psd in ['gaba', 'hbcd']:
+    elif psd in ('gaba', 'hbcd'):
         data, meta, dwelltime, fname_suffix = _process_gaba(pfile)
     elif 'jpress_ac' in psd:  # Bergen patch
         data, meta, dwelltime, fname_suffix = _process_gaba(pfile)


### PR DESCRIPTION
Consistency with previous lines:
https://github.com/wtclarke/spec2nii/blob/fee31415e84bc8dc306f2115dffafddcee03c32c/spec2nii/GE/ge_pfile.py#L94-L97