### PR TITLE
`{str(x)}` → `{x}`

### DIFF
--- a/spec2nii/Siemens/dicomfunctions.py
+++ b/spec2nii/Siemens/dicomfunctions.py
@@ -105,7 +105,7 @@ def multi_file_dicom(files_in, fname_out, tag, verbose):
             else:
                 print(f'Skipping {fn}.')
                 print('Raised IncompatibleSOPClassUID error. Moving to next file.')
-                print(f'Message: {str(exc)}\n')
+                print(f'Message: {exc}\n')
                 continue
 
         if mrs_type == 'SVS':


### PR DESCRIPTION
This is the default, from [Format Specification Mini-Language](https://docs.python.org/3/library/string.html#format-specification-mini-language):
> A general convention is that an empty format specification produces the same result as if you had called [`str()`](https://docs.python.org/3/library/stdtypes.html#str) on the value. A non-empty format specification typically modifies the result.