### PR TITLE
Add a duecredit citation for whenever spec2nii is used

### DIFF
--- a/spec2nii/__init__.py
+++ b/spec2nii/__init__.py
@@ -5,4 +5,4 @@ __version__ = _version.get_versions()['version']
 
 # Register the duecredit citation for spec2nii
 due.cite(Doi('10.1002/mrm.29418'), description='Multi-format in vivo MR spectroscopy conversion to NIFTI',
-         path='spec2nii', version=__version__, tag='reference-implementation', cite_module=True)
+         path='spec2nii', version=__version__, tags=['reference-implementation'], cite_module=True)

--- a/spec2nii/__init__.py
+++ b/spec2nii/__init__.py
@@ -1,7 +1,3 @@
 from . import _version
-from .due import due, Doi
 
 __version__ = _version.get_versions()['version']
-
-# Register the duecredit citation for spec2nii
-due.cite(Doi('10.1002/mrm.29418'), description='Multi-format in vivo MR spectroscopy conversion to NIFTI', path='spec2nii', version=__version__)

--- a/spec2nii/__init__.py
+++ b/spec2nii/__init__.py
@@ -1,3 +1,8 @@
 from . import _version
+from .due import due, Doi
 
 __version__ = _version.get_versions()['version']
+
+# Register the duecredit citation for spec2nii
+due.cite(Doi('10.1002/mrm.29418'), description='Multi-format in vivo MR spectroscopy conversion to NIFTI',
+         path='spec2nii', version=__version__, tag='reference-implementation', cite_module=True)

--- a/spec2nii/__init__.py
+++ b/spec2nii/__init__.py
@@ -1,2 +1,7 @@
 from . import _version
+from .due import due, Doi
+
 __version__ = _version.get_versions()['version']
+
+# Register the duecredit citation for spec2nii
+due.cite(Doi('10.1002/mrm.29418'), description='Multi-format in vivo MR spectroscopy conversion to NIFTI', path='spec2nii', version=__version__)

--- a/spec2nii/due.py
+++ b/spec2nii/due.py
@@ -1,0 +1,74 @@
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+"""
+
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
+
+To use it, place it into your project codebase to be imported, e.g. copy as
+
+    cp stub.py /path/tomodule/module/due.py
+
+Note that it might be better to avoid naming it duecredit.py to avoid shadowing
+installed duecredit.
+
+Then use in your code as
+
+    from .due import due, Doi, BibTeX, Text
+
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2021  DueCredit developers
+License:    BSD-2
+"""
+
+__version__ = '0.0.9'
+
+
+class InactiveDueCreditCollector(object):
+    """Just a stub at the Collector which would not do anything"""
+    def _donothing(self, *args, **kwargs):
+        """Perform no good and no bad"""
+        pass
+
+    def dcite(self, *args, **kwargs):
+        """If I could cite I would"""
+        def nondecorating_decorator(func):
+            return func
+        return nondecorating_decorator
+
+    active = False
+    activate = add = cite = dump = load = _donothing
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+def _donothing_func(*args, **kwargs):
+    """Perform no good and no bad"""
+    pass
+
+
+try:
+    from duecredit import due, BibTeX, Doi, Url, Text  # lgtm [py/unused-import]
+    if 'due' in locals() and not hasattr(due, 'cite'):
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
+except Exception as e:
+    if not isinstance(e, ImportError):
+        import logging
+        logging.getLogger("duecredit").error(
+            "Failed to import duecredit due to %s" % str(e))
+    # Initiate due stub
+    due = InactiveDueCreditCollector()
+    BibTeX = Doi = Url = Text = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:

--- a/spec2nii/spec2nii.py
+++ b/spec2nii/spec2nii.py
@@ -11,7 +11,7 @@ import sys
 import os.path as op
 from pathlib import Path
 import json
-
+from .due import due, Doi
 from nibabel.nifti2 import Nifti2Image
 from spec2nii import __version__ as spec2nii_ver
 # There are case specific imports below
@@ -675,6 +675,8 @@ class spec2nii:
         self.imageOut, self.fileoutNames = insert_hdr_ext(args)
 
 
+# Register the duecredit citation for spec2nii
+@due.dcite(Doi('10.1002/mrm.29418'), description='Multi-format in vivo MR spectroscopy conversion to NIFTI')
 def main(*args):
     spec2nii(*args)
     return 0

--- a/spec2nii/spec2nii.py
+++ b/spec2nii/spec2nii.py
@@ -675,8 +675,6 @@ class spec2nii:
         self.imageOut, self.fileoutNames = insert_hdr_ext(args)
 
 
-# Register the duecredit citation for spec2nii
-@due.dcite(Doi('10.1002/mrm.29418'), description='Multi-format in vivo MR spectroscopy conversion to NIFTI', version=spec2nii_ver)
 def main(*args):
     spec2nii(*args)
     return 0

--- a/spec2nii/spec2nii.py
+++ b/spec2nii/spec2nii.py
@@ -676,7 +676,7 @@ class spec2nii:
 
 
 # Register the duecredit citation for spec2nii
-@due.dcite(Doi('10.1002/mrm.29418'), description='Multi-format in vivo MR spectroscopy conversion to NIFTI')
+@due.dcite(Doi('10.1002/mrm.29418'), description='Multi-format in vivo MR spectroscopy conversion to NIFTI', version=spec2nii_ver)
 def main(*args):
     spec2nii(*args)
     return 0

--- a/spec2nii/spec2nii.py
+++ b/spec2nii/spec2nii.py
@@ -11,7 +11,6 @@ import sys
 import os.path as op
 from pathlib import Path
 import json
-from .due import due, Doi
 from nibabel.nifti2 import Nifti2Image
 from spec2nii import __version__ as spec2nii_ver
 # There are case specific imports below


### PR DESCRIPTION
This shouldn't interfere with spec2nii in any way (and because of the due.py stub file, duecredit doesn't need to be a requirement of spec2nii)