### PR TITLE
Add support for .txt files exported by older versions of jMRUI

### DIFF
--- a/spec2nii/jmrui.py
+++ b/spec2nii/jmrui.py
@@ -246,7 +246,7 @@ def readjMRUItxt(filename):
         Header information
 
     """
-    signalRe = re.compile(r'Signal (\d{1,}) out of (\d{1,}) in file')
+    signalRe = re.compile(r'Signal (?:number: |)(\d{1,}) out of (\d{1,}) in file')
     headerRe = re.compile(r'(\w*):(.*)')
     header = {}
     data   = []


### PR DESCRIPTION
Expanded 'signal' regular expression to include syntax from earlier jMRUI versions (which refer to 'Signal number: 1 out of 1 in file' rather than 'Signal 1 out of 1 in file', for example). Example jMRUI .txt file from jMRUI v3 attached:
[P31rest_proc_jmrui.txt](https://github.com/wtclarke/spec2nii/files/14758951/P31rest_proc_jmrui.txt)

