### PR TITLE
Pydicom compatibility

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,8 @@
 dependencies:
  - numpy>=1.26
  - nibabel
- - pydicom
+ - pydicom==3.*;python_version>=3.10
+ - pydicom==2.4.*;python_version==3.9
  - pyMapVBVD>=0.6.0
  - scipy==1.13.*
  - brukerapi>=0.1.8

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,8 +1,8 @@
 dependencies:
  - numpy>=1.26
  - nibabel
- - pydicom==3.*;python_version>=3.10
- - pydicom==2.4.*;python_version==3.9
+ - pydicom==3.*;python_version>="3.10"
+ - pydicom==2.4.*;python_version<"3.10"
  - pyMapVBVD>=0.6.0
  - scipy==1.13.*
  - brukerapi>=0.1.8

--- a/spec2nii/spec2nii.py
+++ b/spec2nii/spec2nii.py
@@ -467,9 +467,9 @@ class spec2nii:
                         sorted(args.file.rglob('*.IMA')) + \
                         sorted(args.file.rglob('*.ima')) + \
                         sorted(args.file.rglob('*.dcm'))
-                    file = pdcm.read_file(files_in[0])
+                    file = pdcm.dcmread(files_in[0])
                 else:
-                    file = pdcm.read_file(args.file)
+                    file = pdcm.dcmread(args.file)
 
                 manufacturer = file.Manufacturer
                 setattr(args, 'tag', None)


### PR DESCRIPTION
Pydicom >=3 is only [compatible](https://github.com/pydicom/pydicom/blob/93e897c74edbeeca2cb7b6031dab18ac61aaf574/doc/faq/index.rst#what-version-of-python-can-i-use) with python 3.10 or greater. Pin versions for 3.9