### PR TITLE
allows to convert 3D CRT MRSI form Vienna

### DIFF
--- a/spec2nii/Siemens/dicomfunctions.py
+++ b/spec2nii/Siemens/dicomfunctions.py
@@ -201,14 +201,16 @@ def multi_file_dicom(files_in, fname_out, tag, verbose):
         # Combine data into 5th dimension if needed
         data_in_gr = data_list[gr]
         if len(data_in_gr) > 1:
-            combined_data = np.stack(data_in_gr, axis=-1)
+        	combined_data = np.stack(data_in_gr, axis=-1)
+        	combined_data = np.moveaxis(combined_data, (0, 1, 2, 3, 4), (0, 1, 4, 3, 2))
         else:
-            combined_data = data_in_gr[0]
-
+        	combined_data = data_in_gr[0]
+	
         # Add dimension information (if not None for default)
         if tag:
             meta_used.set_dim_info(0, tag)
 
+	
         # Create NIFTI MRS object.
         try:
             nifti_mrs_out.append(gen_nifti_mrs_hdr_ext(combined_data, dt_used, meta_used, or_used.Q44, no_conj=True))
@@ -395,7 +397,7 @@ def process_siemens_csi_vx(img, verbose):
     # slices = int(xprot[('sSpecPara', 'lFinalMatrixSizeSlice')])
     # spectral_points = int(xprot[('sSpecPara', 'lVectorSize')])
 
-    specDataCmplx = specDataCmplx.reshape((slices, rows, cols, spectral_points))
+    specDataCmplx = specDataCmplx.reshape((1, rows, cols, spectral_points))
     specDataCmplx = np.moveaxis(specDataCmplx, (0, 1, 2), (2, 1, 0))
 
     # 1) Extract dicom parameters


### PR DESCRIPTION
Tests were performed on spectroscopy dicoms from 3D CRT MRSI data, a single scan with resolution 32x32x31 was put in single folder, a dicom per slice. The error using previous version of spec2nii read:
  File "/home/bdymerska/.conda/envs/fsl_mrs_env/lib/python3.11/site-packages/spec2nii/Siemens/dicomfunctions.py", line 398, in process_siemens_csi_vx
    specDataCmplx = specDataCmplx.reshape((slices, rows, cols, spectral_points))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: cannot reshape array of size 1048576 into shape (31,32,32,1024)

Resolved by the proposed changes to the dicomfunctions.py.
This provides correct images and appropriate dimensions of the resulting nifti's.
Please note this modification may not generalise to other acquisitions.