### PR TITLE
GE P-file reader: adaptive character encoding

### DIFF
--- a/spec2nii/GE/ge_pfile.py
+++ b/spec2nii/GE/ge_pfile.py
@@ -90,7 +90,7 @@ def _process_svs_pfile(pfile):
     :return: List of file name suffixes
     """
 
-    assert(pfile.encoding is not None) # encoding should have been set in ge_read_pfile get_mapper
+    assert pfile.encoding is not None  # encoding should have been set in ge_read_pfile get_mapper
 
     psd = pfile.hdr.rhi_psdname.decode(pfile.encoding, errors='replace').lower()
     proto = pfile.hdr.rhs_se_desc.decode(pfile.encoding, errors='replace').lower()
@@ -433,7 +433,7 @@ def _process_mrsi_pfile(pfile):
     :return: List of file name suffixes
     """
 
-    assert(pfile.encoding is not None) # encoding should have been set in ge_read_pfile get_mapper
+    assert pfile.encoding is not None  # encoding should have been set in ge_read_pfile get_mapper
 
     psd = pfile.hdr.rhi_psdname.decode(pfile.encoding, errors='replace').lower()
 
@@ -591,7 +591,11 @@ def _populate_metadata(pfile, water_suppressed=True, data_dimensions=None):
     # 'TxCoil'
     # Not Known
     # 'RxCoil'
-    meta.set_user_def(key='ReceiveCoilName', value=hdr.rhi_cname.decode(pfile.encoding, errors='replace'), doc='Rx coil name.')
+    meta.set_user_def(
+        key="ReceiveCoilName",
+        value=hdr.rhi_cname.decode(pfile.encoding, errors="replace"),
+        doc="Rx coil name.",
+    )
 
     # # 5.3 Sequence information
     # 'SequenceName'

--- a/spec2nii/GE/ge_pfile.py
+++ b/spec2nii/GE/ge_pfile.py
@@ -89,12 +89,15 @@ def _process_svs_pfile(pfile):
     :return: List of NIFTI MRS data objects
     :return: List of file name suffixes
     """
-    psd = pfile.hdr.rhi_psdname.decode('utf-8').lower()
-    proto = pfile.hdr.rhs_se_desc.decode('utf-8').lower()
+
+    assert(pfile.encoding is not None) # encoding should have been set in ge_read_pfile get_mapper
+
+    psd = pfile.hdr.rhi_psdname.decode(pfile.encoding, errors='replace').lower()
+    proto = pfile.hdr.rhs_se_desc.decode(pfile.encoding, errors='replace').lower()
     if psd == 'hbcd' and "press" in proto:
         print('\nPSD was: ', psd)
         print('Proto is: ', proto)
-        psd = pfile.hdr.rhs_se_desc.decode('utf-8').lower()
+        psd = pfile.hdr.rhs_se_desc.decode(pfile.encoding, errors='replace').lower()
         print('PSD updated to: ', psd)
 
     # MM: Some 'gaba' psd strings contain full path names, so truncate to the end of the path
@@ -429,7 +432,10 @@ def _process_mrsi_pfile(pfile):
     :return: List of NIFTI MRS data objects
     :return: List of file name suffixes
     """
-    psd = pfile.hdr.rhi_psdname.decode('utf-8').lower()
+
+    assert(pfile.encoding is not None) # encoding should have been set in ge_read_pfile get_mapper
+
+    psd = pfile.hdr.rhi_psdname.decode(pfile.encoding, errors='replace').lower()
 
     known_formats = ('probe-p', 'probe-sl', 'slaser_cni', 'presscsi')
     if psd not in known_formats:
@@ -573,37 +579,37 @@ def _populate_metadata(pfile, water_suppressed=True, data_dimensions=None):
     # 'Manufacturer'
     meta.set_standard_def('Manufacturer', 'GE')
     # 'ManufacturersModelName'
-    meta.set_standard_def('ManufacturersModelName', hdr.rhe_ex_sysid.decode('utf-8'))
+    meta.set_standard_def('ManufacturersModelName', hdr.rhe_ex_sysid.decode(pfile.encoding, errors='replace'))
     # 'DeviceSerialNumber'
-    meta.set_standard_def('DeviceSerialNumber', hdr.rhe_uniq_sys_id.decode('utf-8'))
+    meta.set_standard_def('DeviceSerialNumber', hdr.rhe_uniq_sys_id.decode(pfile.encoding, errors='replace'))
     # 'SoftwareVersions'
-    meta.set_standard_def('SoftwareVersions', hdr.rhe_ex_verscre.decode('utf-8'))
+    meta.set_standard_def('SoftwareVersions', hdr.rhe_ex_verscre.decode(pfile.encoding, errors='replace'))
     # 'InstitutionName'
-    meta.set_standard_def('InstitutionName', hdr.rhe_hospname.decode('utf-8'))
+    meta.set_standard_def('InstitutionName', hdr.rhe_hospname.decode(pfile.encoding, errors='replace'))
     # 'InstitutionAddress'
     # Not known
     # 'TxCoil'
     # Not Known
     # 'RxCoil'
-    meta.set_user_def(key='ReceiveCoilName', value=hdr.rhi_cname.decode('utf-8'), doc='Rx coil name.')
+    meta.set_user_def(key='ReceiveCoilName', value=hdr.rhi_cname.decode(pfile.encoding, errors='replace'), doc='Rx coil name.')
 
     # # 5.3 Sequence information
     # 'SequenceName'
-    meta.set_standard_def('SequenceName', hdr.rhi_psdname.decode('utf-8'))
+    meta.set_standard_def('SequenceName', hdr.rhi_psdname.decode(pfile.encoding, errors='replace'))
     # 'ProtocolName'
-    meta.set_standard_def('ProtocolName', hdr.rhs_se_desc.decode('utf-8'))
+    meta.set_standard_def('ProtocolName', hdr.rhs_se_desc.decode(pfile.encoding, errors='replace'))
 
     # # 5.4 Sequence information
     # 'PatientPosition'
     # Not known
     # 'PatientName'
-    meta.set_standard_def('PatientName', hdr.rhe_patname.decode('utf-8'))
+    meta.set_standard_def('PatientName', hdr.rhe_patname.decode(pfile.encoding, errors='replace'))
     # 'PatientID'
     # Not known
     # 'PatientWeight'
     # Not known
     # 'PatientDoB'
-    meta.set_standard_def('PatientDoB', hdr.rhe_dateofbirth.decode('utf-8'))
+    meta.set_standard_def('PatientDoB', hdr.rhe_dateofbirth.decode(pfile.encoding, errors='replace'))
     # 'PatientSex'
     if hdr.rhe_patsex == 1:
         sex_str = 'M'

--- a/spec2nii/GE/ge_read_pfile.py
+++ b/spec2nii/GE/ge_read_pfile.py
@@ -194,14 +194,14 @@ class Pfile:
 
                 if psd == "hbcd" and "press" in proto:
                     psd = self.hdr.rhs_se_desc.decode(encoding, errors).lower()
-            except UnicodeDecodeError as err:
+            except UnicodeDecodeError:
                 psd = ""
                 proto = ""
                 continue
             self.encoding = encoding
             break
 
-        assert(self.encoding is not None) # final codec must should have succeeded
+        assert self.encoding is not None  # final codec must should have succeeded
 
         # MM: Some 'gaba' psd strings contain full path names, so truncate to the end of the path
         if psd.endswith('gaba'):
@@ -667,7 +667,7 @@ class PfileMapper:
 
         dcos[0][0] = (self.hdr.rhi_trhc_R - self.hdr.rhi_tlhc_R)
         dcos[0][1] = (self.hdr.rhi_trhc_A - self.hdr.rhi_tlhc_A)
-        dcos[0][2] =  (self.hdr.rhi_trhc_S - self.hdr.rhi_tlhc_S)
+        dcos[0][2] = (self.hdr.rhi_trhc_S - self.hdr.rhi_tlhc_S)
 
         dcosLengthX = np.sqrt(dcos[0][0] * dcos[0][0]
                               + dcos[0][1] * dcos[0][1]
@@ -679,7 +679,7 @@ class PfileMapper:
 
         dcos[1][0] = (self.hdr.rhi_brhc_R - self.hdr.rhi_trhc_R)
         dcos[1][1] = (self.hdr.rhi_brhc_A - self.hdr.rhi_trhc_A)
-        dcos[1][2] =  (self.hdr.rhi_brhc_S - self.hdr.rhi_trhc_S)
+        dcos[1][2] = (self.hdr.rhi_brhc_S - self.hdr.rhi_trhc_S)
 
         dcosLengthY = np.sqrt(dcos[1][0] * dcos[1][0]
                               + dcos[1][1] * dcos[1][1]
@@ -1008,7 +1008,7 @@ class PfileMapper:
         numTimePts      = self.get_num_time_points
         numSpecPts      = self.hdr.rhr_rh_frame_size
         numFreqPts      = numSpecPts
-        numComponents   =  2
+        numComponents   = 2
         dataWordSize    = self.hdr.rhr_rh_point_size
 
         numBytesInVol   = self.get_num_kspace_points * numSpecPts * numComponents * dataWordSize

--- a/tests/test_ge_pfile.py
+++ b/tests/test_ge_pfile.py
@@ -40,7 +40,7 @@ bergen_press_301 = ge_path / 'pFiles' / 'PRESS' / 'MR30.1' / 'P30101.7'
 bergen_press_301_non_english = ge_path / 'pFiles' / 'PRESS' / 'MR30.1' / 'P30104.7'
 
 
-def testsvs(tmp_path):
+def test_svs(tmp_path):
 
     subprocess.check_call(['spec2nii', 'ge',
                            '-f', 'svs',
@@ -72,7 +72,7 @@ def testsvs(tmp_path):
     assert np.isclose(hdr_ext['RepetitionTime'], 2.0)
 
 
-def testmrsi(tmp_path):
+def test_mrsi(tmp_path):
 
     subprocess.check_call(['spec2nii', 'ge',
                            '-f', 'mrsi',
@@ -94,7 +94,7 @@ def testmrsi(tmp_path):
     assert hdr_ext['OriginalFile'][0] == mrsi_path.name
 
 
-def testmpress(tmp_path):
+def test_mpress(tmp_path):
 
     subprocess.check_call(['spec2nii', 'ge',
                            '-f', 'mpress',
@@ -127,7 +127,7 @@ def testmpress(tmp_path):
     assert np.isclose(hdr_ext['RepetitionTime'], 2.0)
 
 
-def testmm_hercules(tmp_path):
+def test_mm_hercules(tmp_path):
     for path in mm_herc:
         subprocess.run([
             'spec2nii', 'ge',
@@ -164,7 +164,7 @@ def testmm_hercules(tmp_path):
         assert hdr_ext_ref['dim_7'] == 'DIM_EDIT'
 
 
-def testmm_hermes(tmp_path):
+def test_mm_hermes(tmp_path):
     for path in mm_hermes:
         subprocess.run([
             'spec2nii', 'ge',
@@ -200,7 +200,7 @@ def testmm_hermes(tmp_path):
         assert hdr_ext_ref['dim_7'] == 'DIM_EDIT'
 
 
-def testmm_mega(tmp_path):
+def test_mm_mega(tmp_path):
     for path in mm_mega.rglob('*.7'):
         subprocess.run([
             'spec2nii', 'ge',
@@ -242,7 +242,7 @@ def testmm_mega(tmp_path):
         assert hdr_ext_ref['dim_7'] == 'DIM_EDIT'
 
 
-def testmm_press(tmp_path):
+def test_mm_press(tmp_path):
     for path in mm_press.rglob('*.7'):
         subprocess.run([
             'spec2nii', 'ge',
@@ -277,7 +277,7 @@ def testmm_press(tmp_path):
         assert hdr_ext_ref['dim_6'] == 'DIM_DYN'
 
 
-def testmm_press_noid(tmp_path):
+def test_mm_press_noid(tmp_path):
     subprocess.run([
         'spec2nii', 'ge',
         '-f', mm_press_noid.stem,
@@ -304,7 +304,7 @@ def testmm_press_noid(tmp_path):
     assert hdr_ext_ref['dim_5'] == 'DIM_COIL'
 
 
-def testmm_slaser(tmp_path):
+def test_mm_slaser(tmp_path):
     subprocess.run([
         'spec2nii', 'ge',
         '-f', mm_slaser.stem,
@@ -331,7 +331,7 @@ def testmm_slaser(tmp_path):
     assert hdr_ext_ref['dim_5'] == 'DIM_COIL'
 
 
-def testhbcd_isthmus(tmp_path):
+def test_hbcd_isthmus(tmp_path):
     subprocess.run([
         'spec2nii', 'ge',
         '-f', 'hbcd',
@@ -361,7 +361,7 @@ def testhbcd_isthmus(tmp_path):
     assert img.dim_tags == ['DIM_DYN', 'DIM_COIL', None]
 
 
-def testsvs_bergen_301(tmp_path):
+def test_svs_bergen_301(tmp_path):
 
     subprocess.check_call(['spec2nii', 'ge',
                            '-f', 'svs',
@@ -395,7 +395,7 @@ def testsvs_bergen_301(tmp_path):
     assert hdr_ext['ProtocolName'] == 'PROBE-P'
 
 
-def testsvs_bergen_301_non_english(tmp_path):
+def test_svs_bergen_301_non_english(tmp_path):
 
     subprocess.check_call(['spec2nii', 'ge',
                            '-f', 'svs',


### PR DESCRIPTION
`ge_read_pfile` and `ge_pfile` assumed utf-8 encoding in character strings within the p-file; this does not appear to be standard across systems. Suggested patch attempts a few likely encoding candidates, before falling back on a permissive ascii encoding.

After initial detection, subsequent conversions are more forgiving of an incorrect detection (substituting unknown characters, rather than crashing).

This bugfix allows us to also quantify data acquired from the right (høyre) side, and should also handle local patient names better.