### PR TITLE
Bump conda-incubator/setup-miniconda

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           submodules: true
           lfs: true
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Update from v2 to v3. v3.0.0 was released more than a year ago.