### PR TITLE
Modify read_spar to accept encoding parameter

### DIFF
--- a/spec2nii/Philips/philips.py
+++ b/spec2nii/Philips/philips.py
@@ -101,7 +101,7 @@ def read_sdat_spar_pair(sdat_file, spar_file, shape=None, tags=None, fileout=Non
                [mainStr, ]
 
 
-def read_spar(filename):
+def read_spar(filename, encoding='utf-8'):
     '''Read the .spar file.
     :param filename: file path
 
@@ -110,7 +110,7 @@ def read_spar(filename):
     '''
 
     parameter_dict = {}
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding=encoding) as f:
         for line in f:
             # ignore comments (!) and empty lines
             if line == "\n" or line.startswith("!"):


### PR DESCRIPTION
Added encoding parameter to read_spar function for file reading.

Sometimes Philips .PAR and .SPAR contain special letters especially in subject names, which makes the files non utf-8 encoded. Therefore by adding i.e. encoding="iso-8859-1" to pythons "open" function makes the reading possible. I have added the encoding parameter as an input argument (default: utf-8) for backward compatibility.

Would be ideal if python could sort out the encoding automatically but that is not standard.

PS. I did not change the help docstring to add info on the encoding argument. This should likely be added.

Best
ulindberg