### PR TITLE
Enh/clean subcmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 This document contains the Spec2nii release history in reverse chronological order.
 
-0.8.8 (WIP)
+0.8.8 (Tuesday 14th April 2026)
 ----------------------------------
 - Special case handling of DICOM files for dkd_svs_slaser_moconav - awaiting test data.
 - Remove Python 3.9 (eol) from supported versions, add 3.14.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ This document contains the Spec2nii release history in reverse chronological ord
 
 0.8.8 (Tuesday 14th April 2026)
 ----------------------------------
+- Added 'clean' subcommand for updating invalid header extensions 
 - Special case handling of DICOM files for dkd_svs_slaser_moconav - awaiting test data.
 - Remove Python 3.9 (eol) from supported versions, add 3.14.
 - Automatic encoding detection for SPAR and rda files (by chardet)

--- a/spec2nii/other.py
+++ b/spec2nii/other.py
@@ -132,7 +132,7 @@ def clean_hdr_ext(args):
             v_minor = json_def['nifti_mrs_version']['minor']
             img.header['intent_name'] = f'mrs_v{v_major}_{v_minor}'.encode()
             print(f"'intent_name' is updated to 'mrs_v{v_major}_{v_minor}'.")
-        
+
         # save file to output and re-read it
         args.outdir.mkdir(parents=True, exist_ok=True)
         if args.fileout:

--- a/spec2nii/other.py
+++ b/spec2nii/other.py
@@ -1,7 +1,9 @@
 """Module containing other miscellaneous functions
 
-Author: William Clarke <william.clarke@ndcn.ox.ac.uk>
-Copyright (C) 2021 University of Oxford
+Author:  William Clarke         <william.clarke@ndcn.ox.ac.uk>
+         Vasilis Karlaftis      <vasilis.karlaftis@ndcn.ox.ac.uk>
+
+Copyright (C) 2026 University of Oxford
 """
 import json
 import pprint
@@ -103,27 +105,40 @@ def clean_hdr_ext(args):
     nifti_mrs_img = NIFTI_MRS(args.file, validate_on_creation=False)
     new_hdr = nifti_mrs_img.hdr_ext.copy()
 
-    # check that 'SpectrometerFrequency' is an array of floats
+    # # override SpectrometerFrequency if 'args.override_frequency' is specified
+    # if args.override_frequency:
+    #     new_hdr.SpectrometerFrequency = args.override_frequency
+    # # override ResonantNucleus if 'args.override_nucleus' is specified
+    # if args.override_nucleus:
+    #     new_hdr.ResonantNucleus = args.override_nucleus
+    # # override dwelltime if 'args.override_dwelltime' is specified
+    # if args.override_dwelltime:
+    #     nifti_mrs_img.dwelltime = args.override_dwelltime
+
+    # 1. check that 'SpectrometerFrequency' is an array of floats
     val = new_hdr.SpectrometerFrequency
     if not isinstance(val, (list, tuple, ndarray)) or (isinstance(val, ndarray) and val.ndim == 0):
         val = [val]
     new_hdr.SpectrometerFrequency = [float(v) for v in val]
+    print("'SpectrometerFrequency' is updated.")
 
-    # check that 'ResonantNucleus' is an array of strings
+    # 2. check that 'ResonantNucleus' is an array of strings
     val = new_hdr.ResonantNucleus
-    if not isinstance(val, (list, tuple)):
+    if not isinstance(val, (list, tuple, ndarray)) or (isinstance(val, ndarray) and val.ndim == 0):
         val = [val]
     new_hdr.ResonantNucleus = [str(v) for v in val]
+    print("'ResonantNucleus' is updated.")
 
-    # check that 'SpectralWidth' is equal to 1/pixdim[4]
+    # 3. check that 'SpectralWidth' is equal to 1/pixdim[4]
     if 'SpectralWidth' in new_hdr:
         spec_width = new_hdr['SpectralWidth']
         if not isclose(spec_width, 1 / nifti_mrs_img.dwelltime, atol=1E-2):
             print("Warning: 'SpectralWidth' does not match '1/dwelltime'! "
-                  f"Replacing with the latter: {1/nifti_mrs_img.dwelltime}")
+                  f"Replacing with the latter: {1 / nifti_mrs_img.dwelltime}")
     new_hdr.set_standard_def('SpectralWidth', 1 / nifti_mrs_img.dwelltime)
+    print("'SpectralWidth' is updated.")
 
-    # check that intent is of a valid format
+    # 4. check that intent is of a valid format
     intent_ptrn = re.compile(r'mrs_v\d+_\d+')
     intent_str = nifti_mrs_img.header.get_intent()[2]
     if intent_str is None or intent_str == '' or intent_ptrn.match(intent_str) is None:
@@ -135,21 +150,24 @@ def clean_hdr_ext(args):
         v_major = json_def['nifti_mrs_version']['major']
         v_minor = json_def['nifti_mrs_version']['minor']
         nifti_mrs_img.header['intent_name'] = f'mrs_v{v_major}_{v_minor}'.encode()
+        print(f"'intent_name' is updated to 'mrs_v{v_major}_{v_minor}'.")
+    else:
+        print("'intent_name' is valid.")
 
-    # check that user-defined fields are dictionary with a 'Description' field
+    # 5. check that user-defined fields are dictionary with a 'Description' field
     dim_re = re.compile(r"^dim_[567](_((info)|(header)))?$")
     for key in new_hdr:
         if key not in standard_defined\
-            and key != "SpectrometerFrequency"\
-            and key != "ResonantNucleus"\
-            and key != "SpectralWidth"\
-            and not dim_re.match(key):
+           and key != "SpectrometerFrequency"\
+           and key != "ResonantNucleus"\
+           and not dim_re.match(key):
             # Must be user-defined, convert it to a dictionary with empty 'Description'
             if not isinstance(new_hdr[key], dict):
                 val = new_hdr[key]
                 new_hdr.set_user_def(key, val, '')
             elif "Description" not in new_hdr[key]:
                 new_hdr[key]["Description"] = ''
+            print(f"'{key}' is updated with empty 'Description'.")
 
     # update NIfTI-MRS header extension
     nifti_mrs_img.hdr_ext = new_hdr

--- a/spec2nii/other.py
+++ b/spec2nii/other.py
@@ -85,3 +85,89 @@ def insert_hdr_ext(args):
         fname_out = [args.file.with_suffix('').with_suffix('').name, ]
 
     return [nifti_mrs_img, ], fname_out
+
+
+def clean_hdr_ext(args):
+    """Function for updating invalid fields in NIfTI-MRS header.
+
+    :param args: Command line arguments parsed in spec2nii.py
+    :return: Modified NIfTI-MRS file
+    :rtype: [nifti_mrs.nifti_mrs.NIFTI_MRS,]
+    :return: List of output names
+    :rtype: [str,]
+    """
+    import re
+    from numpy import isclose, ndarray
+    from nifti_mrs.definitions import standard_defined
+
+    nifti_mrs_img = NIFTI_MRS(args.file, validate_on_creation=False)
+    new_hdr = nifti_mrs_img.hdr_ext.copy()
+
+    # override SpectrometerFrequency if 'args.override_frequency' is specified
+    if args.override_frequency is not None:
+        new_hdr.SpectrometerFrequency = args.override_frequency
+    # override ResonantNucleus if 'args.override_nucleus' is specified
+    if args.override_nucleus is not None:
+        new_hdr.ResonantNucleus = args.override_nucleus
+    # override dwelltime if 'args.override_dwelltime' is specified
+    if args.override_dwelltime is not None:
+        nifti_mrs_img.dwelltime = args.override_dwelltime
+        nifti_mrs_img.header['pixdim'][4] = args.override_dwelltime
+
+    # check that 'SpectrometerFrequency' is an array of floats
+    val = new_hdr.SpectrometerFrequency
+    if not isinstance(val, (list, tuple, ndarray)) or (isinstance(val, ndarray) and val.ndim == 0):
+        val = [val]
+    new_hdr.SpectrometerFrequency = [float(v) for v in val]
+
+    # check that 'ResonantNucleus' is an array of strings
+    val = new_hdr.ResonantNucleus
+    if not isinstance(val, (list, tuple)):
+        val = [val]
+    new_hdr.ResonantNucleus = [str(v) for v in val]
+
+    # check that 'SpectralWidth' is equal to 1/pixdim[4]
+    if 'SpectralWidth' in new_hdr:
+        spec_width = new_hdr['SpectralWidth']
+        if not isclose(spec_width, 1 / nifti_mrs_img.dwelltime, atol=1E-2):
+            print("Warning: 'SpectralWidth' does not match '1/dwelltime'! "
+                  f"Replacing with the latter: {1/nifti_mrs_img.dwelltime}")
+    new_hdr.set_standard_def('SpectralWidth', 1 / nifti_mrs_img.dwelltime)
+
+    # check that intent is of a valid format
+    intent_ptrn = re.compile(r'mrs_v\d+_\d+')
+    intent_str = nifti_mrs_img.header.get_intent()[2]
+    if intent_str is None or intent_str == '' or intent_ptrn.match(intent_str) is None:
+        import json
+        from importlib.resources import files
+        data_text = files('nifti_mrs.standard').joinpath('definitions.json').read_text(encoding='utf-8')
+        json_def = json.loads(data_text)
+
+        v_major = json_def['nifti_mrs_version']['major']
+        v_minor = json_def['nifti_mrs_version']['minor']
+        nifti_mrs_img.header['intent_name'] = f'mrs_v{v_major}_{v_minor}'.encode()
+
+    # check that user-defined fields are dictionary with a 'Description' field
+    dim_re = re.compile(r"^dim_[567](_((info)|(header)))?$")
+    for key in new_hdr:
+        if key not in standard_defined\
+            and key != "SpectrometerFrequency"\
+            and key != "ResonantNucleus"\
+            and key != "SpectralWidth"\
+            and not dim_re.match(key):
+            # Must be user-defined, convert it to a dictionary with empty 'Description'
+            if not isinstance(new_hdr[key], dict):
+                val = new_hdr[key]
+                new_hdr.set_user_def(key, val, '')
+            elif "Description" not in new_hdr[key]:
+                new_hdr[key]["Description"] = ''
+
+    # update NIfTI-MRS header extension
+    nifti_mrs_img.hdr_ext = new_hdr
+
+    if args.fileout:
+        fname_out = [args.fileout, ]
+    else:
+        fname_out = [args.file.with_suffix('').with_suffix('').name, ]
+
+    return [nifti_mrs_img, ], fname_out

--- a/spec2nii/other.py
+++ b/spec2nii/other.py
@@ -102,7 +102,46 @@ def clean_hdr_ext(args):
     from numpy import isclose, ndarray
     from nifti_mrs.definitions import standard_defined
 
-    nifti_mrs_img = NIFTI_MRS(args.file, validate_on_creation=False)
+    # Try reading the file as NIfTI-MRS
+    try:
+        nifti_mrs_img = NIFTI_MRS(args.file, validate_on_creation=False)
+        print("'intent_name' is valid.")
+    except NotNIFTI_MRS as exc:
+        if str(exc) != 'NIFTI-MRS intent code not set.':
+            raise
+        # if failed, read as a regular NIfTI, update intent and re-save
+        from fsl.data.image import Image
+        from nifti_mrs.hdr_ext import Hdr_Ext
+        img = Image(args.file)
+        hdr_ext_codes = img.header.extensions.get_codes()
+        if 44 not in hdr_ext_codes:
+            raise NotNIFTI_MRS('NIFTI-MRS must have a header extension.')
+        img._hdr_ext = Hdr_Ext.from_header_ext(
+            img.header.extensions[hdr_ext_codes.index(44)].json())
+
+        # 1. check that intent is of a valid format
+        intent_ptrn = re.compile(r'mrs_v\d+_\d+')
+        intent_str = img.header.get_intent()[2]
+        if intent_str is None or intent_str == '' or intent_ptrn.match(intent_str) is None:
+            import json
+            from importlib.resources import files
+            data_text = files('nifti_mrs.standard').joinpath('definitions.json').read_text(encoding='utf-8')
+            json_def = json.loads(data_text)
+
+            v_major = json_def['nifti_mrs_version']['major']
+            v_minor = json_def['nifti_mrs_version']['minor']
+            img.header['intent_name'] = f'mrs_v{v_major}_{v_minor}'.encode()
+            print(f"'intent_name' is updated to 'mrs_v{v_major}_{v_minor}'.")
+        
+        # save file to output and re-read it
+        args.outdir.mkdir(parents=True, exist_ok=True)
+        if args.fileout:
+            args.file = args.outdir / args.fileout
+        else:
+            args.file = args.outdir / args.file.with_suffix('').with_suffix('').name
+        img.save(args.file)
+        nifti_mrs_img = NIFTI_MRS(args.file, validate_on_creation=False)
+
     new_hdr = nifti_mrs_img.hdr_ext.copy()
 
     # # override SpectrometerFrequency if 'args.override_frequency' is specified
@@ -115,21 +154,21 @@ def clean_hdr_ext(args):
     # if args.override_dwelltime:
     #     nifti_mrs_img.dwelltime = args.override_dwelltime
 
-    # 1. check that 'SpectrometerFrequency' is an array of floats
+    # 2. check that 'SpectrometerFrequency' is an array of floats
     val = new_hdr.SpectrometerFrequency
     if not isinstance(val, (list, tuple, ndarray)) or (isinstance(val, ndarray) and val.ndim == 0):
         val = [val]
     new_hdr.SpectrometerFrequency = [float(v) for v in val]
     print("'SpectrometerFrequency' is updated.")
 
-    # 2. check that 'ResonantNucleus' is an array of strings
+    # 3. check that 'ResonantNucleus' is an array of strings
     val = new_hdr.ResonantNucleus
     if not isinstance(val, (list, tuple, ndarray)) or (isinstance(val, ndarray) and val.ndim == 0):
         val = [val]
     new_hdr.ResonantNucleus = [str(v) for v in val]
     print("'ResonantNucleus' is updated.")
 
-    # 3. check that 'SpectralWidth' is equal to 1/pixdim[4]
+    # 4. check that 'SpectralWidth' is equal to 1/pixdim[4]
     if 'SpectralWidth' in new_hdr:
         spec_width = new_hdr['SpectralWidth']
         if not isclose(spec_width, 1 / nifti_mrs_img.dwelltime, atol=1E-2):
@@ -137,22 +176,6 @@ def clean_hdr_ext(args):
                   f"Replacing with the latter: {1 / nifti_mrs_img.dwelltime}")
     new_hdr.set_standard_def('SpectralWidth', 1 / nifti_mrs_img.dwelltime)
     print("'SpectralWidth' is updated.")
-
-    # 4. check that intent is of a valid format
-    intent_ptrn = re.compile(r'mrs_v\d+_\d+')
-    intent_str = nifti_mrs_img.header.get_intent()[2]
-    if intent_str is None or intent_str == '' or intent_ptrn.match(intent_str) is None:
-        import json
-        from importlib.resources import files
-        data_text = files('nifti_mrs.standard').joinpath('definitions.json').read_text(encoding='utf-8')
-        json_def = json.loads(data_text)
-
-        v_major = json_def['nifti_mrs_version']['major']
-        v_minor = json_def['nifti_mrs_version']['minor']
-        nifti_mrs_img.header['intent_name'] = f'mrs_v{v_major}_{v_minor}'.encode()
-        print(f"'intent_name' is updated to 'mrs_v{v_major}_{v_minor}'.")
-    else:
-        print("'intent_name' is valid.")
 
     # 5. check that user-defined fields are dictionary with a 'Description' field
     dim_re = re.compile(r"^dim_[567](_((info)|(header)))?$")

--- a/spec2nii/other.py
+++ b/spec2nii/other.py
@@ -144,29 +144,19 @@ def clean_hdr_ext(args):
 
     new_hdr = nifti_mrs_img.hdr_ext.copy()
 
-    # # override SpectrometerFrequency if 'args.override_frequency' is specified
-    # if args.override_frequency:
-    #     new_hdr.SpectrometerFrequency = args.override_frequency
-    # # override ResonantNucleus if 'args.override_nucleus' is specified
-    # if args.override_nucleus:
-    #     new_hdr.ResonantNucleus = args.override_nucleus
-    # # override dwelltime if 'args.override_dwelltime' is specified
-    # if args.override_dwelltime:
-    #     nifti_mrs_img.dwelltime = args.override_dwelltime
-
     # 2. check that 'SpectrometerFrequency' is an array of floats
     val = new_hdr.SpectrometerFrequency
     if not isinstance(val, (list, tuple, ndarray)) or (isinstance(val, ndarray) and val.ndim == 0):
         val = [val]
     new_hdr.SpectrometerFrequency = [float(v) for v in val]
-    print("'SpectrometerFrequency' is updated.")
+    print("'SpectrometerFrequency' format is updated.")
 
     # 3. check that 'ResonantNucleus' is an array of strings
     val = new_hdr.ResonantNucleus
     if not isinstance(val, (list, tuple, ndarray)) or (isinstance(val, ndarray) and val.ndim == 0):
         val = [val]
     new_hdr.ResonantNucleus = [str(v) for v in val]
-    print("'ResonantNucleus' is updated.")
+    print("'ResonantNucleus' format is updated.")
 
     # 4. check that 'SpectralWidth' is equal to 1/pixdim[4]
     if 'SpectralWidth' in new_hdr:
@@ -174,8 +164,9 @@ def clean_hdr_ext(args):
         if not isclose(spec_width, 1 / nifti_mrs_img.dwelltime, atol=1E-2):
             print("Warning: 'SpectralWidth' does not match '1/dwelltime'! "
                   f"Replacing with the latter: {1 / nifti_mrs_img.dwelltime}")
+    else:
+        print("'SpectralWidth' is added.")
     new_hdr.set_standard_def('SpectralWidth', 1 / nifti_mrs_img.dwelltime)
-    print("'SpectralWidth' is updated.")
 
     # 5. check that user-defined fields are dictionary with a 'Description' field
     dim_re = re.compile(r"^dim_[567](_((info)|(header)))?$")

--- a/spec2nii/other.py
+++ b/spec2nii/other.py
@@ -103,17 +103,6 @@ def clean_hdr_ext(args):
     nifti_mrs_img = NIFTI_MRS(args.file, validate_on_creation=False)
     new_hdr = nifti_mrs_img.hdr_ext.copy()
 
-    # override SpectrometerFrequency if 'args.override_frequency' is specified
-    if args.override_frequency is not None:
-        new_hdr.SpectrometerFrequency = args.override_frequency
-    # override ResonantNucleus if 'args.override_nucleus' is specified
-    if args.override_nucleus is not None:
-        new_hdr.ResonantNucleus = args.override_nucleus
-    # override dwelltime if 'args.override_dwelltime' is specified
-    if args.override_dwelltime is not None:
-        nifti_mrs_img.dwelltime = args.override_dwelltime
-        nifti_mrs_img.header['pixdim'][4] = args.override_dwelltime
-
     # check that 'SpectrometerFrequency' is an array of floats
     val = new_hdr.SpectrometerFrequency
     if not isinstance(val, (list, tuple, ndarray)) or (isinstance(val, ndarray) and val.ndim == 0):

--- a/spec2nii/spec2nii.py
+++ b/spec2nii/spec2nii.py
@@ -340,21 +340,6 @@ class spec2nii:
             if args.override_nucleus:
                 nifti_mrs_img.hdr_ext.ResonantNucleus = args.override_nucleus
 
-            # if args.override_nucleus or args.override_frequency:
-            #     from nibabel.nifti1 import Nifti1Extension
-            #     hdr_ext_codes = nifti_mrs_img.header.extensions.get_codes()
-            #     index = hdr_ext_codes.index(44)
-            #     original = json.loads(nifti_mrs_img.header.extensions[index].get_content())
-
-            #     if args.override_nucleus:
-            #         original['ResonantNucleus'] = args.override_nucleus
-            #     if args.override_frequency:
-            #         original['SpectrometerFrequency'] = args.override_frequency
-            #     json_s = json.dumps(original)
-            #     new_ext = Nifti1Extension(44, json_s.encode('UTF-8'))
-            #     nifti_mrs_img.header.extensions.clear()
-            #     nifti_mrs_img.header.extensions.append(new_ext)
-
     def insert_spectralwidth(self):
         """Ensure that the correct spectral width is inserted into the header extension"""
         for nifti_mrs_img in self.imageOut:

--- a/spec2nii/spec2nii.py
+++ b/spec2nii/spec2nii.py
@@ -2,8 +2,10 @@
 
 This module contains the main class to be called as a script (through the main function).
 
-Author: William Clarke <william.clarke@ndcn.ox.ac.uk>
-Copyright (C) 2020 University of Oxford
+Author:  William Clarke         <william.clarke@ndcn.ox.ac.uk>
+         Vasilis Karlaftis      <vasilis.karlaftis@ndcn.ox.ac.uk>
+
+Copyright (C) 2026 University of Oxford
 """
 
 import argparse
@@ -330,22 +332,28 @@ class spec2nii:
         """Implement any command line overrides for essential parameters."""
         for nifti_mrs_img in self.imageOut:
             if args.override_dwelltime:
-                nifti_mrs_img.dwelltime(args.override_dwelltime)
+                nifti_mrs_img.dwelltime = args.override_dwelltime
 
-            if args.override_nucleus or args.override_frequency:
-                from nibabel.nifti1 import Nifti1Extension
-                hdr_ext_codes = nifti_mrs_img.header.extensions.get_codes()
-                index = hdr_ext_codes.index(44)
-                original = json.loads(nifti_mrs_img.header.extensions[index].get_content())
+            if args.override_frequency:
+                nifti_mrs_img.hdr_ext.SpectrometerFrequency = args.override_frequency
 
-                if args.override_nucleus:
-                    original['ResonantNucleus'] = args.override_nucleus
-                if args.override_frequency:
-                    original['SpectrometerFrequency'] = args.override_frequency
-                json_s = json.dumps(original)
-                new_ext = Nifti1Extension(44, json_s.encode('UTF-8'))
-                nifti_mrs_img.header.extensions.clear()
-                nifti_mrs_img.header.extensions.append(new_ext)
+            if args.override_nucleus:
+                nifti_mrs_img.hdr_ext.ResonantNucleus = args.override_nucleus
+
+            # if args.override_nucleus or args.override_frequency:
+            #     from nibabel.nifti1 import Nifti1Extension
+            #     hdr_ext_codes = nifti_mrs_img.header.extensions.get_codes()
+            #     index = hdr_ext_codes.index(44)
+            #     original = json.loads(nifti_mrs_img.header.extensions[index].get_content())
+
+            #     if args.override_nucleus:
+            #         original['ResonantNucleus'] = args.override_nucleus
+            #     if args.override_frequency:
+            #         original['SpectrometerFrequency'] = args.override_frequency
+            #     json_s = json.dumps(original)
+            #     new_ext = Nifti1Extension(44, json_s.encode('UTF-8'))
+            #     nifti_mrs_img.header.extensions.clear()
+            #     nifti_mrs_img.header.extensions.append(new_ext)
 
     def insert_spectralwidth(self):
         """Ensure that the correct spectral width is inserted into the header extension"""

--- a/spec2nii/spec2nii.py
+++ b/spec2nii/spec2nii.py
@@ -280,6 +280,18 @@ class spec2nii:
                                    verbose=False,
                                    anon=False)
 
+        parser_clean = subparsers.add_parser('clean', help='Update invalid fields in NIfTI-MRS header.')
+        parser_clean.add_argument('file', help='NIfTI-MRS file', type=Path)
+        parser_clean = add_common_parameters(parser_clean)
+        parser_clean.set_defaults(func=self.clean,
+                                  nifti1=False,
+                                  json=False,
+                                  override_nucleus=None,
+                                  override_frequency=None,
+                                  override_dwelltime=None,
+                                  verbose=False,
+                                  anon=False)
+
         if len(sys.argv) == 1:
             parser.print_usage(sys.stderr)
             sys.exit(1)
@@ -695,6 +707,11 @@ class spec2nii:
     def insert(self, args):
         from spec2nii.other import insert_hdr_ext
         self.imageOut, self.fileoutNames = insert_hdr_ext(args)
+
+    # Clean function
+    def clean(self, args):
+        from spec2nii.other import clean_hdr_ext
+        self.imageOut, self.fileoutNames = clean_hdr_ext(args)
 
 
 def main(*args):

--- a/spec2nii/spec2nii.py
+++ b/spec2nii/spec2nii.py
@@ -330,7 +330,7 @@ class spec2nii:
         """Implement any command line overrides for essential parameters."""
         for nifti_mrs_img in self.imageOut:
             if args.override_dwelltime:
-                nifti_mrs_img.set_dwell_time(args.override_dwelltime)
+                nifti_mrs_img.dwelltime(args.override_dwelltime)
 
             if args.override_nucleus or args.override_frequency:
                 from nibabel.nifti1 import Nifti1Extension

--- a/tests/test_other_func.py
+++ b/tests/test_other_func.py
@@ -218,11 +218,11 @@ def test_clean_intent(tmp_path):
     # Create files with invalid intents to be "cleaned"
     img = read_nifti_mrs(data_clean_path)
     img.header['intent_name'] = 'mrs_v2_1'.encode()
-    nib.save(img, tmp_path / 'invalid1.nii.gz')
+    nib.save(img, tmp_path / 'valid.nii.gz')
     img.header['intent_name'] = ''.encode()
-    nib.save(img, tmp_path / 'invalid2.nii.gz')
+    nib.save(img, tmp_path / 'invalid1.nii.gz')
     img.header['intent_name'] = None
-    nib.save(img, tmp_path / 'invalid3.nii.gz')
+    nib.save(img, tmp_path / 'invalid2.nii.gz')
 
     # Create reference intent_name
     data_text = files('nifti_mrs.standard').joinpath('definitions.json').read_text(encoding='utf-8')
@@ -232,7 +232,7 @@ def test_clean_intent(tmp_path):
     intent_name = f'mrs_v{v_major}_{v_minor}'.encode()
 
     # Test clean call on this file
-    for file, intent in zip(['invalid1.nii.gz', 'invalid2.nii.gz', 'invalid3.nii.gz'],
+    for file, intent in zip(['valid', 'invalid1', 'invalid2'],
                             ['mrs_v2_1'.encode(), intent_name, intent_name]):
         subprocess.check_call(['spec2nii', 'clean',
                             '-o', tmp_path,

--- a/tests/test_other_func.py
+++ b/tests/test_other_func.py
@@ -10,12 +10,11 @@ Subject to the BSD 3-Clause License.
 import subprocess
 from pathlib import Path
 import json
-
+from importlib.resources import files
 import nibabel as nib
 import numpy as np
 import pytest
 from fsl.data.image import Image
-
 from .io_for_tests import read_nifti_mrs, read_nifti_mrs_with_hdr
 
 # Data paths
@@ -131,7 +130,7 @@ def test_insert_not_nmrs(tmp_path):
 
 def test_clean_outputs(tmp_path):
 
-    # test a call with -o and -f arguments
+    # Test a call with -o and -f arguments
     subprocess.check_call(['spec2nii', 'clean',
                            '-o', tmp_path,
                            '-f', 'cleaned',
@@ -140,7 +139,7 @@ def test_clean_outputs(tmp_path):
     assert (tmp_path / 'cleaned.nii.gz').exists()
     img1, hdr1 = read_nifti_mrs_with_hdr(tmp_path / 'cleaned.nii.gz')
 
-    # test a call with -o argument
+    # Test a call with -o argument
     subprocess.check_call(['spec2nii', 'clean',
                            '-o', tmp_path,
                            str(data_clean_path)])
@@ -148,7 +147,7 @@ def test_clean_outputs(tmp_path):
     assert (tmp_path / data_clean_path.name).exists()
     img2, hdr2 = read_nifti_mrs_with_hdr(tmp_path / data_clean_path.name)
 
-    # test a call with -f argument
+    # Test a call with -f argument
     subprocess.check_call(['spec2nii', 'clean',
                            '-f', 'cleaned',
                            str(data_clean_path)])
@@ -156,7 +155,7 @@ def test_clean_outputs(tmp_path):
     assert Path('cleaned.nii.gz').exists()
     img3, hdr3 = read_nifti_mrs_with_hdr('cleaned.nii.gz')
 
-    # test a call with no arguments
+    # Test a call with no arguments
     subprocess.check_call(['spec2nii', 'clean',
                            str(data_clean_path)])
 
@@ -174,7 +173,7 @@ def test_clean_outputs(tmp_path):
     assert hdr1 == hdr2 == hdr3 == hdr4
     assert hdr1 != orig_hdr
 
-    # cleanup files created in current directory
+    # Cleanup files created in current directory
     Path('cleaned.nii.gz').unlink()
     Path(data_clean_path.name).unlink()
 
@@ -213,6 +212,48 @@ def test_clean_invalid_file(tmp_path):
     assert cln_hdr_ext['SpectralWidth']         == 1 / cln_img.header['pixdim'][4]
     assert cln_hdr_ext['BadUserField']          == {'Value': 7, 'Description': ''}
     assert cln_hdr_ext['UserFieldNoDesc']       == {'Value': 'abc', 'Description': ''}
+
+
+def test_clean_intent(tmp_path):
+    # Create files with invalid intents to be "cleaned"
+    img = read_nifti_mrs(data_clean_path)
+    img.header['intent_name'] = 'mrs_v2_1'.encode()
+    nib.save(img, tmp_path / 'invalid1.nii.gz')
+    img.header['intent_name'] = ''.encode()
+    nib.save(img, tmp_path / 'invalid2.nii.gz')
+    img.header['intent_name'] = None
+    nib.save(img, tmp_path / 'invalid3.nii.gz')
+
+    # Create reference intent_name
+    data_text = files('nifti_mrs.standard').joinpath('definitions.json').read_text(encoding='utf-8')
+    json_def = json.loads(data_text)
+    v_major = json_def['nifti_mrs_version']['major']
+    v_minor = json_def['nifti_mrs_version']['minor']
+    intent_name = f'mrs_v{v_major}_{v_minor}'.encode()
+
+    # Test clean call on this file
+    for file, intent in zip(['invalid1.nii.gz', 'invalid2.nii.gz', 'invalid3.nii.gz'],
+                            ['mrs_v2_1'.encode(), intent_name, intent_name]):
+        subprocess.check_call(['spec2nii', 'clean',
+                            '-o', tmp_path,
+                            '-f', 'cleaned',
+                            str(tmp_path / file)])
+
+        orig_img, orig_hdr_ext  = read_nifti_mrs_with_hdr(data_clean_path)
+        cln_img, cln_hdr_ext    = read_nifti_mrs_with_hdr(tmp_path / 'cleaned.nii.gz')
+
+        assert cln_img.shape == orig_img.shape
+        assert np.allclose(cln_img.get_fdata(dtype=complex), orig_img.get_fdata(dtype=complex))
+        # make sure the only difference in the header is the 'intent_name' field
+        assert cln_img.header['intent_name'] != orig_img.header['intent_name']
+        assert cln_img.header['intent_name'] == intent
+        orig_img.header['intent_name']  = cln_img.header['intent_name']
+        assert cln_img.header == orig_img.header
+        # make sure the only difference in hdr_ext is the 'dim_5_use' and 'SpectralWidth' fields
+        assert cln_hdr_ext != orig_hdr_ext
+        orig_hdr_ext['dim_5_use']       = cln_hdr_ext['dim_5_use']
+        orig_hdr_ext['SpectralWidth']   = cln_hdr_ext['SpectralWidth']
+        assert cln_hdr_ext == orig_hdr_ext
 
 
 def test_clean_overrides(tmp_path):

--- a/tests/test_other_func.py
+++ b/tests/test_other_func.py
@@ -1,6 +1,9 @@
-'''Tests for spec2nii dump, extract and insert functions.
+'''Tests for spec2nii dump, extract, insert and clean functions.
 
-Copyright William Clarke, University of Oxford 2021
+Author:  William Clarke         <william.clarke@ndcn.ox.ac.uk>
+         Vasilis Karlaftis      <vasilis.karlaftis@ndcn.ox.ac.uk>
+
+Copyright (C) 2026 University of Oxford
 Subject to the BSD 3-Clause License.
 '''
 
@@ -8,62 +11,54 @@ import subprocess
 from pathlib import Path
 import json
 
+import nibabel as nib
 import numpy as np
+import pytest
 from fsl.data.image import Image
 
-from .io_for_tests import read_nifti_mrs
+from .io_for_tests import read_nifti_mrs, read_nifti_mrs_with_hdr
 
 # Data paths
 siemens_path = Path(__file__).parent / 'spec2nii_test_data' / 'Siemens'
 data_path = siemens_path / 'VBData' / 'Twix' / 'meas_MID151_svs_se_C_T15_S10_10_FID108741.dat'
+data_clean_path = Path(__file__).parent / 'spec2nii_test_data' / 'other' / 'file_to_clean.nii.gz'
 
-
-def test_dump(tmp_path):
-    # Convert twix
+# Convert Twix data
+@pytest.fixture
+def converted_twix(tmp_path):
     subprocess.check_call(['spec2nii', 'twix',
                            '-e', 'image',
                            '-f', 'original',
                            '-o', tmp_path,
                            '-j', str(data_path)])
+    return tmp_path / 'original.nii.gz'
 
-    subprocess.check_call(['spec2nii', 'dump', str(tmp_path / 'original.nii.gz')])
+
+def test_dump(converted_twix):
+    subprocess.check_call(['spec2nii', 'dump', str(converted_twix)])
 
 
-def test_extract(tmp_path):
-    # Convert twix
-    subprocess.check_call(['spec2nii', 'twix',
-                           '-e', 'image',
-                           '-f', 'original',
-                           '-o', tmp_path,
-                           '-j', str(data_path)])
+def test_extract(tmp_path, converted_twix):
 
     subprocess.check_call(['spec2nii', 'extract',
                            '-o', tmp_path,
-                           str(tmp_path / 'original.nii.gz')])
+                           str(converted_twix)])
 
     assert (tmp_path / 'original.json').exists()
 
     with open(tmp_path / 'original.json') as jf:
         extracted_hdr = json.load(jf)
 
-    img = read_nifti_mrs(tmp_path / 'original.nii.gz')
-    hdr_ext_codes = img.header.extensions.get_codes()
-    hdr_ext = json.loads(img.header.extensions[hdr_ext_codes.index(44)].get_content())
+    img, hdr_ext = read_nifti_mrs_with_hdr(converted_twix)
 
     assert extracted_hdr == hdr_ext
 
 
-def test_insert(tmp_path):
-    # Convert twix
-    subprocess.check_call(['spec2nii', 'twix',
-                           '-e', 'image',
-                           '-f', 'original',
-                           '-o', tmp_path,
-                           '-j', str(data_path)])
+def test_insert(tmp_path, converted_twix):
 
     subprocess.check_call(['spec2nii', 'extract',
                            '-o', tmp_path,
-                           str(tmp_path / 'original.nii.gz')])
+                           str(converted_twix)])
 
     assert (tmp_path / 'original.json').exists()
 
@@ -79,12 +74,10 @@ def test_insert(tmp_path):
                            '-o', tmp_path,
                            '-f', 'new',
                            '--dwelltime', '0.0005',
-                           str(tmp_path / 'original.nii.gz'),
+                           str(converted_twix),
                            str(tmp_path / 'new.json')])
 
-    img = read_nifti_mrs(tmp_path / 'new.nii.gz')
-    hdr_ext_codes = img.header.extensions.get_codes()
-    hdr_ext = json.loads(img.header.extensions[hdr_ext_codes.index(44)].get_content())
+    img, hdr_ext = read_nifti_mrs_with_hdr(tmp_path / 'new.nii.gz')
 
     assert extracted_hdr == hdr_ext
     assert np.isclose(img.header['pixdim'][4], 0.0005)
@@ -118,9 +111,7 @@ def test_insert_not_nmrs(tmp_path):
                            str(tmp_path / 'noncompliant.nii.gz'),
                            str(tmp_path / 'new.json')])
 
-    img = read_nifti_mrs(tmp_path / 'compliant.nii.gz')
-    hdr_ext_codes = img.header.extensions.get_codes()
-    hdr_ext = json.loads(img.header.extensions[hdr_ext_codes.index(44)].get_content())
+    img, hdr_ext = read_nifti_mrs_with_hdr(tmp_path / 'compliant.nii.gz')
 
     assert hdr_ext['ResonantNucleus'][0] == '1H'
     assert img.header.get_intent()[2].split('_')[0] == 'mrs'
@@ -136,3 +127,111 @@ def test_insert_not_nmrs(tmp_path):
 
     img = read_nifti_mrs(tmp_path / 'compliant_dt.nii.gz')
     assert np.isclose(img.header['pixdim'][4], 0.0005)
+
+
+def test_clean_outputs(tmp_path):
+
+    # test a call with -o and -f arguments
+    subprocess.check_call(['spec2nii', 'clean',
+                           '-o', tmp_path,
+                           '-f', 'cleaned',
+                           str(data_clean_path)])
+    
+    assert (tmp_path / 'cleaned.nii.gz').exists()
+    img1, hdr1 = read_nifti_mrs_with_hdr(tmp_path / 'cleaned.nii.gz')
+
+    # test a call with -o argument
+    subprocess.check_call(['spec2nii', 'clean',
+                           '-o', tmp_path,
+                           str(data_clean_path)])
+
+    assert (tmp_path / data_clean_path.name).exists()
+    img2, hdr2 = read_nifti_mrs_with_hdr(tmp_path / data_clean_path.name)
+
+    # test a call with -f argument
+    subprocess.check_call(['spec2nii', 'clean',
+                           '-f', 'cleaned',
+                           str(data_clean_path)])
+    
+    assert Path('cleaned.nii.gz').exists()
+    img3, hdr3 = read_nifti_mrs_with_hdr('cleaned.nii.gz')
+
+    # test a call with no arguments
+    subprocess.check_call(['spec2nii', 'clean',
+                           str(data_clean_path)])
+
+    assert Path(data_clean_path.name).exists()
+    img4, hdr4 = read_nifti_mrs_with_hdr(data_clean_path.name)
+
+    orig_img, orig_hdr = read_nifti_mrs_with_hdr(data_clean_path)
+
+    assert img1.shape == img2.shape == img3.shape == img4.shape == orig_img.shape
+    assert np.allclose(img1.get_fdata(dtype=complex), img2.get_fdata(dtype=complex))
+    assert np.allclose(img1.get_fdata(dtype=complex), img3.get_fdata(dtype=complex))
+    assert np.allclose(img1.get_fdata(dtype=complex), img4.get_fdata(dtype=complex))
+    assert np.allclose(img1.get_fdata(dtype=complex), orig_img.get_fdata(dtype=complex))
+    assert img1.header == img2.header == img3.header == img4.header == orig_img.header
+    assert hdr1 == hdr2 == hdr3 == hdr4
+    assert hdr1 != orig_hdr
+
+    # cleanup files created in current directory
+    Path('cleaned.nii.gz').unlink()
+    Path(data_clean_path.name).unlink()
+
+
+def test_clean_invalid_file(tmp_path):
+    # Create file with many invalid fields to be "cleaned"
+    img, hdr_ext = read_nifti_mrs_with_hdr(data_clean_path)
+    hdr_ext['SpectrometerFrequency'] = 123.4
+    hdr_ext['ResonantNucleus'] = '1H'
+    hdr_ext['SpectralWidth'] = 1.0
+    hdr_ext['BadUserField'] = 7
+    hdr_ext['UserFieldNoDesc'] = {'Value': 'abc'}
+
+    hdr_ext_codes = img.header.extensions.get_codes()
+    extension = nib.nifti1.Nifti1Extension(44, json.dumps(hdr_ext).encode('UTF-8'))
+    img.header.extensions[hdr_ext_codes.index(44)] = extension
+    nib.save(img, tmp_path / 'invalid.nii.gz')
+
+    # Test clean call on this file
+    subprocess.check_call(['spec2nii', 'clean',
+                           '-o', tmp_path,
+                           '-f', 'cleaned',
+                           str(tmp_path / 'invalid.nii.gz')])
+
+    orig_img, orig_hdr_ext  = read_nifti_mrs_with_hdr(data_clean_path)
+    cln_img, cln_hdr_ext    = read_nifti_mrs_with_hdr(tmp_path / 'cleaned.nii.gz')
+
+    assert cln_img.shape == orig_img.shape
+    assert np.allclose(cln_img.get_fdata(dtype=complex), orig_img.get_fdata(dtype=complex))
+    assert cln_img.header == orig_img.header
+    assert cln_hdr_ext != orig_hdr_ext
+    
+    assert cln_hdr_ext['SpectrometerFrequency'] == [123.4]
+    assert cln_hdr_ext['ResonantNucleus']       == ['1H']
+    assert cln_hdr_ext['SpectralWidth']         != 1.0
+    assert cln_hdr_ext['SpectralWidth']         == 1 / cln_img.header['pixdim'][4]
+    assert cln_hdr_ext['BadUserField']          == {'Value': 7, 'Description': ''}
+    assert cln_hdr_ext['UserFieldNoDesc']       == {'Value': 'abc', 'Description': ''}
+
+
+def test_clean_overrides(tmp_path):
+    # Test override call for 'SpectrometerFrequency', 'ResonantNucleus', and 'dwelltime'
+    subprocess.check_call(['spec2nii', 'clean',
+                           '-o', tmp_path,
+                           '-f', 'cleaned',
+                           '--override_frequency', '111.1', '222.2',
+                           '--override_nucleus', '31P',
+                           '--override_dwelltime', '0.0001',
+                           str(data_clean_path)])
+
+    orig_img, orig_hdr_ext  = read_nifti_mrs_with_hdr(data_clean_path)
+    cln_img, cln_hdr_ext    = read_nifti_mrs_with_hdr(tmp_path / 'cleaned.nii.gz')
+
+    assert cln_hdr_ext['SpectrometerFrequency'] != orig_hdr_ext['SpectrometerFrequency']
+    assert cln_hdr_ext['SpectrometerFrequency'] == [111.1, 222.2]
+    assert cln_hdr_ext['ResonantNucleus']       != orig_hdr_ext['ResonantNucleus']
+    assert cln_hdr_ext['ResonantNucleus']       == ['31P']
+    assert not np.isclose(orig_img.header['pixdim'][4], 0.0001)
+    assert np.isclose(cln_img.header['pixdim'][4], 0.0001)
+    assert np.isclose(cln_hdr_ext['SpectralWidth'], 1/0.0001)

--- a/tests/test_philips_dicom.py
+++ b/tests/test_philips_dicom.py
@@ -10,7 +10,7 @@ import json
 
 import numpy as np
 
-from .io_for_tests import read_nifti_mrs
+from .io_for_tests import read_nifti_mrs, read_nifti_mrs_with_hdr
 
 # Data paths
 philips_path = Path(__file__).parent / 'spec2nii_test_data' / 'philips'
@@ -42,6 +42,30 @@ def test_svs(tmp_path):
     assert hdr_ext['ResonantNucleus'][0] == '1H'
     assert hdr_ext['OriginalFile'][0] == data_path.name
 
+    assert (tmp_path / 'svs_ref.nii.gz').is_file()
+
+
+def test_svs_overrides(tmp_path):
+
+    subprocess.check_call(['spec2nii', 'philips_dcm',
+                           '-f', 'svs',
+                           '-o', tmp_path,
+                           '-j',
+                           str(data_path),
+                           '--override_frequency', '100',
+                           '--override_nucleus', '31P',
+                           '--override_dwelltime', '0.0001'])
+
+    img_t, hdr_ext = read_nifti_mrs_with_hdr(tmp_path / 'svs.nii.gz')
+
+    assert img_t.shape == (1, 1, 1, 1024)
+    assert np.iscomplexobj(img_t.dataobj)
+
+    assert hdr_ext['SpectrometerFrequency'] == [100.0, ]
+    assert hdr_ext['ResonantNucleus'] == ['31P']
+    assert np.isclose(img_t.header['pixdim'][4], 0.0001)
+
+    assert hdr_ext['OriginalFile'][0] == data_path.name
     assert (tmp_path / 'svs_ref.nii.gz').is_file()
 
 


### PR DESCRIPTION
- Added 'clean' subcommand for updating invalid header extensions: SpectrometerFrequency, ResonantNucleus, dwelltime, intent_name and user-defined fields