### PR TITLE
GE: use RxCoil string metadata for BIDS compatibility

### DIFF
--- a/spec2nii/GE/ge_pfile.py
+++ b/spec2nii/GE/ge_pfile.py
@@ -609,11 +609,7 @@ def _populate_metadata(pfile, water_suppressed=True, data_dimensions=None):
     # 'TxCoil'
     # Not Known
     # 'RxCoil'
-    meta.set_user_def(
-        key="ReceiveCoilName",
-        value=hdr.rhi_cname.decode(pfile.encoding, errors="replace"),
-        doc="Rx coil name.",
-    )
+    meta.set_standard_def('RxCoil', hdr.rhi_cname.decode(pfile.encoding, errors='replace'))
 
     # # 5.3 Sequence information
     # 'SequenceName'

--- a/tests/test_ge_pfile.py
+++ b/tests/test_ge_pfile.py
@@ -67,6 +67,8 @@ def test_svs(tmp_path):
     assert hdr_ext['SpectrometerFrequency'][0] == 127.76365
     assert hdr_ext['ResonantNucleus'][0] == '1H'
     assert hdr_ext['OriginalFile'][0] == svs_path.name
+    assert isinstance(hdr_ext['RxCoil'], str)
+    assert 'ReceiveCoilName' not in hdr_ext
 
     assert np.isclose(hdr_ext['EchoTime'], 0.27)
     assert np.isclose(hdr_ext['RepetitionTime'], 2.0)


### PR DESCRIPTION
Replace GE user-defined ReceiveCoilName object metadata with standard RxCoil string metadata to avoid nested Value/Description JSON output. Add regression assertions in GE tests. Refs #194.